### PR TITLE
Fix for select input boxes that are styled

### DIFF
--- a/jquery.cascadingdropdown.js
+++ b/jquery.cascadingdropdown.js
@@ -81,8 +81,10 @@
                         var requirementsMet = true;
 
                         $.each(requiredSelectBoxes, function () {
-                            var className = '.' + this.className;
-                            var changedSelectBoxObject = $.grep(options.selectBoxes, function (e) { return e.selector == className; })[0];
+                            var selectBox = this;
+                            var changedSelectBoxObject = $.grep(options.selectBoxes, function (e) { 
+                                return $(selectBox).hasClass(e.selector.replace(".","")); 
+                            })[0];
 
                             if(changedSelectBoxObject.paramName){
                                 ajaxData[changedSelectBoxObject.paramName] = this.value;


### PR DESCRIPTION
Most forms are css styled so select boxes can have any number of css
classes.
Replaced class equality with jQuery's hasClass.
