### PR TITLE
Support data-selected-value attribute in element

### DIFF
--- a/src/jquery.cascadingdropdown.js
+++ b/src/jquery.cascadingdropdown.js
@@ -8,6 +8,12 @@
 
     // Constructor
     function Dropdown(options, parent) {
+        // Get the selected value from data-selected-value attribute of the element
+        if (!options.selected) {
+            var value = $(options.selector).data('selected-value');
+            options.selected = value ? value.toString() : options.selected;
+        }
+        
         this.el = $(options.selector, parent.el);
         this.parent = parent;
         this.options = $.extend({}, defaultOptions, options);

--- a/src/jquery.cascadingdropdown.js
+++ b/src/jquery.cascadingdropdown.js
@@ -11,7 +11,9 @@
         // Get the selected value from data-selected-value attribute of the element
         if (!options.selected) {
             var value = $(options.selector).data('selected-value');
-            options.selected = value ? value.toString() : options.selected;
+            if (value){
+                options.selected = value.toString() 
+            }
         }
         
         this.el = $(options.selector, parent.el);


### PR DESCRIPTION
Add the support of data-selected-value in the dropdown element.

```html
<select class="step1" name="screen" data-selected-value="4.3">
	<option value="">Screen size</option>
	<option value="4">4.0"</option>
	<option value="4.3">4.3"</option>
	<option value="4.7">4.7"</option>
	<option value="5">5.0"</option>
</select>
<select class="step2" name="resolution" data-selected-value="720p">
	<option value="">Screen resolution</option>
</select>
```
```javascript
$('#example1').cascadingDropdown({
	selectBoxes: [
		{
			selector: '.step1'
		},
		{
			selector: '.step2',
			requires: ['.step1'],
                        source: function(request, response) {
				$.getJSON('/api/resolutions', request, function(data) {
					var selectOnlyOption = data.length <= 1;
					response($.map(data, function(item, index) {
						return {
							label: item + 'p',
							value: item,
							selected: selectOnlyOption // Select if only option
						};
					}));
				});
			}
		}
	]
});
```